### PR TITLE
Fix: Use VITE_API_BASE_URL environment variable instead of hardcoded …

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,5 @@
 // API Base URL
-
-export const API_BASE_URL = 'http://localhost:8000/api';
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api';
 
 
 // API Endpoints


### PR DESCRIPTION
…localhost